### PR TITLE
Correct syntax to use bule2 in Sudoku examples

### DIFF
--- a/examples/sudoku/sudoku.bul
+++ b/examples/sudoku/sudoku.bul
@@ -1,36 +1,38 @@
 % Bule rules for Sudoku game
 
-dom[1..9].
-boxOffset[0..2,0..2].
+#ground dom[1..9].
+#ground boxOffset[0..2,0..2].
 
-boxBegin[1,1].
-boxBegin[1,4].
-boxBegin[1,7].
-boxBegin[4,1].
-boxBegin[4,4].
-boxBegin[4,7].
-boxBegin[7,1].
-boxBegin[7,4].
-boxBegin[7,7].
+#ground boxBegin[1,1].
+#ground boxBegin[1,4].
+#ground boxBegin[1,7].
+#ground boxBegin[4,1].
+#ground boxBegin[4,4].
+#ground boxBegin[4,7].
+#ground boxBegin[7,1].
+#ground boxBegin[7,4].
+#ground boxBegin[7,7].
+
+dom[X], dom[Y], dom[Z] :: #exists[0] q(X,Y,Z).
 
 % Rules
 % in every cell at least 1 val
-dom[X], dom[Y] :: q(X,Y,Z) : dom[Z].
+dom[X], dom[Y] :: dom[Z] : q(X,Y,Z).
 
 % each val in at least 1 cell
-dom[Z] :: q(X,Y,Z) : dom[X] : dom[Y].
+dom[Z] :: dom[X], dom[Y] : q(X,Y,Z).
 
 % each cell contains no more than 1 val
-dom[X],dom[Y], dom[Z1], dom[Z2], Z1 < Z2 :: ~q(X,Y,Z1), ~q(X,Y,Z2). 
+dom[X], dom[Y], dom[Z1], dom[Z2], Z1 < Z2 :: ~q(X,Y,Z1) | ~q(X,Y,Z2). 
 
 % no two same vals in a column
-dom[X1], dom[X2], X1 < X2 :: ~q(X1,Y,Z), ~q(X2,Y,Z).
+dom[Y], dom[Z], dom[X1], dom[X2], X1 < X2 :: ~q(X1,Y,Z) | ~q(X2,Y,Z).
 
 % no two same vals in a row
-dom[Y1], dom[Y2], Y1 < Y2 :: ~q(X,Y1,Z), ~q(X,Y2,Z).
+dom[X], dom[Z], dom[Y1], dom[Y2], Y1 < Y2 :: ~q(X,Y1,Z) | ~q(X,Y2,Z).
 
 % no two same vals in a single box
 %% note that we do not need the rules for X1==X2 (or Y1==Y2) because they are
 %% implied by 30 (or 27 respectively)
-boxBegin[ROOTX,ROOTY], boxOffset[X1,Y1], boxOffset[X2,Y2], X1<X2, Y1!=Y2
-	:: ~q(ROOTX+X1,ROOTY+Y1,Z), ~q(ROOTX+X2,ROOTY+Y2,Z).
+boxBegin[ROOTX,ROOTY], boxOffset[X1,Y1], boxOffset[X2,Y2], X1<X2, Y1!=Y2, dom[Z]
+	:: ~q(ROOTX+X1,ROOTY+Y1,Z) | ~q(ROOTX+X2,ROOTY+Y2,Z).

--- a/examples/sudoku/sudoku_short.bul
+++ b/examples/sudoku/sudoku_short.bul
@@ -1,24 +1,26 @@
 % Bule rules for Sudoku game
-dom[1..9].
-delta[0..2,0..2].
-start[1].
-start[4].
-start[7].
+#ground dom[1..9].
+#ground delta[0..2,0..2].
+#ground start[1].
+#ground start[4].
+#ground start[7].
+
+dom[X], dom[Y], dom[Z] :: #exists[0] q(X,Y,Z).
 
 % in every cell at least 1 val
-dom[X], dom[Y] :: q(X,Y,Z) : dom[Z].
+dom[X], dom[Y] :: dom[Z] : q(X,Y,Z).
 
 % each cell contains no more than 1 val
-dom[X],dom[Y], dom[Z1], dom[Z2], Z1 < Z2 :: ~q(X,Y,Z1), ~q(X,Y,Z2). 
+dom[X], dom[Y], dom[Z1], dom[Z2], Z1 < Z2 :: ~q(X,Y,Z1) | ~q(X,Y,Z2). 
 
 % in each row (column) each value exists at least once 
-dom[Z],dom[X] :: q(X,Y,Z) : dom[Y].
-dom[Z],dom[Y] :: q(X,Y,Z) : dom[X].
+dom[Z], dom[X] :: dom[Y] : q(X,Y,Z).
+dom[Z], dom[Y] :: dom[X] : q(X,Y,Z).
 
 % no two same vals in a row (column)
-dom[X1], dom[X2], X1 < X2 :: ~q(X1,Y,Z), ~q(X2,Y,Z).
-dom[Y1], dom[Y2], Y1 < Y2 :: ~q(X,Y1,Z), ~q(X,Y2,Z).
+dom[Y], dom[Z], dom[X1], dom[X2], X1 < X2 :: ~q(X1,Y,Z) | ~q(X2,Y,Z).
+dom[X], dom[Z], dom[Y1], dom[Y2], Y1 < Y2 :: ~q(X,Y1,Z) | ~q(X,Y2,Z).
 
 % no two same vals in a single box
-start[RX], start[RY], delta[X1,Y1], delta[X2,Y2], X1<X2, Y1<Y2
-	:: ~q(RX+X1,RY+Y1,Z), ~q(RX+X2,RY+Y2,Z).
+start[RX], start[RY], delta[X1,Y1], delta[X2,Y2], X1<X2, Y1<Y2, dom[Z]
+	:: ~q(RX+X1,RY+Y1,Z) | ~q(RX+X2,RY+Y2,Z).

--- a/readme.md
+++ b/readme.md
@@ -263,8 +263,9 @@ Next, let's define a 2D domain for coordinates offset within a box:
 #ground boxOffset[0..2,0..2].
 ```
 
-Lastly, let's declare variables to represent if a value is at a coordinate
-```
+Lastly, let's declare variables to represent if a value is at a coordinate:
+
+```prolog
 domCoords[X,Y], dom[Z] :: #exists[0] q(X,Y,Z).
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -183,15 +183,15 @@ Say we want to define a domain `dom` on set `{1,2,3}`.\
 We can achieve this with range expression (both brackets are inclusive):
 
 ```prolog
-dom[1..3].
+#ground dom[1..3].
 ```
 
 Will translate to:
 
 ```prolog
-dom[1].
-dom[2].
-dom[3].
+#ground dom[1].
+#ground dom[2].
+#ground dom[3].
 ```
 
 Let us have a 1-arity literal `p(X)`
@@ -234,33 +234,38 @@ Note that adding the rule `Y < 3` skips last iteration step `~q(9)` as `3 < 3` <
 Let's have a domain for single row / single column indexing
 
 ```prolog
-dom[1..9].
+#ground dom[1..9].
 ```
 
 Similarly, let's define a 2D domain for our `X, Y` coordinates:
 
 ```prolog
-domCoords[1..9,1..9].
+#ground domCoords[1..9,1..9].
 ```
 
 Also, let's define a 2D domain for inner-box starting coords:
 
 ```prolog
-boxBegin[1,1].
-boxBegin[1,4].
-boxBegin[1,7].
-boxBegin[4,1].
-boxBegin[4,4].
-boxBegin[4,7].
-boxBegin[7,1].
-boxBegin[7,4].
-boxBegin[7,7].
+#ground boxBegin[1,1].
+#ground boxBegin[1,4].
+#ground boxBegin[1,7].
+#ground boxBegin[4,1].
+#ground boxBegin[4,4].
+#ground boxBegin[4,7].
+#ground boxBegin[7,1].
+#ground boxBegin[7,4].
+#ground boxBegin[7,7].
 ```
 
-Lastly, let's define a 2D domain for coordinates offset within a box:
+Next, let's define a 2D domain for coordinates offset within a box:
 
 ```prolog
-boxOffset[0..2,0..2].
+#ground boxOffset[0..2,0..2].
+```
+
+Lastly, let's declare variables to represent if a value is at a coordinate
+```
+domCoords[X,Y], dom[Z] :: #exists[0] q(X,Y,Z).
 ```
 
 Now, we can start applying Sudoku rules in Bule!


### PR DESCRIPTION
Resolves #31.

I also noticed that the examples inside `examples/sudoku` were outdated, and corrected them to work with bule2.